### PR TITLE
fix: standardize public runtime DLL name

### DIFF
--- a/ParadoxLauncher/UPDATE_CHANNEL.md
+++ b/ParadoxLauncher/UPDATE_CHANNEL.md
@@ -31,7 +31,7 @@ From `ParadoxLauncher`:
 
 ```powershell
 node scripts/publish-runtime-update.mjs `
-  --dll ..\ParadoxRuntime\x64\Release\MystPaxInternalServer.dll `
+  --dll ..\ParadoxRuntime\x64\Release\MysticParadox.dll `
   --extra ..\tools\RuntimeLoader\target\release\winmm.dll `
   --target client `
   --version 0.4.13 `

--- a/ParadoxLauncher/scripts/publish-runtime-update.mjs
+++ b/ParadoxLauncher/scripts/publish-runtime-update.mjs
@@ -38,7 +38,7 @@ const bytes = readFileSync(dllPath);
 if (bytes.length === 0 || bytes.length > 200 * 1024 * 1024) throw new Error("DLL size is outside the safe range");
 
 const sha256 = createHash("sha256").update(bytes).digest("hex");
-const artifactName = `MystPaxInternalServer-${version}-${target}-${targetChangelist}.dll`;
+const artifactName = `MysticParadox-${version}-${target}-${targetChangelist}.dll`;
 const artifactDir = resolve(outputRoot, "runtime", target, channel, "windows-x86_64", version);
 mkdirSync(artifactDir, { recursive: true });
 
@@ -112,7 +112,7 @@ for (const extraPath of extraPaths) {
 
 const manifest = {
   schema: 1,
-  component: "MystPaxInternalServer",
+  component: "ParadoxRuntime",
   target,
   version,
   channel,

--- a/ParadoxLauncher/src-tauri/src/commands/updates.rs
+++ b/ParadoxLauncher/src-tauri/src/commands/updates.rs
@@ -55,7 +55,7 @@ fn is_approved_runtime_url(candidate: &str) -> bool {
     is_approved_runtime_url_for(runtime_endpoint(), candidate)
 }
 const MAX_RUNTIME_BYTES: usize = 200 * 1024 * 1024;
-pub(crate) const RUNTIME_DLL_NAME: &str = "MystPaxInternalServer.dll";
+pub(crate) const RUNTIME_DLL_NAME: &str = "MysticParadox.dll";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -456,7 +456,7 @@ mod tests {
         assert!(!is_safe_extra_name("nested/winmm.dll"));
         assert!(!is_safe_extra_name("notes.txt"));
         assert!(!is_safe_extra_name(RUNTIME_DLL_NAME));
-        assert!(!is_safe_extra_name("mystpaxinternalserver.dll"));
-        assert!(!is_safe_extra_name("MYSTPAXINTERNALSERVER.DLL"));
+        assert!(!is_safe_extra_name("mysticparadox.dll"));
+        assert!(!is_safe_extra_name("MYSTICPARADOX.DLL"));
     }
 }

--- a/ParadoxLauncher/src-tauri/src/install/verify.rs
+++ b/ParadoxLauncher/src-tauri/src/install/verify.rs
@@ -2,7 +2,7 @@ use sha2::{Digest, Sha256};
 use std::path::Path;
 
 const WINMM_DLL_NAME: &str = "winmm.dll";
-const INTERNAL_SERVER_DLL_NAME: &str = "MystPaxInternalServer.dll";
+const RUNTIME_DLL_NAME: &str = "MysticParadox.dll";
 
 pub fn hash_file_sha256(path: &Path) -> Result<String, String> {
     let bytes = std::fs::read(path).map_err(|e| format!("Couldn't read file: {e}"))?;
@@ -18,8 +18,8 @@ pub fn hash_file_sha256(path: &Path) -> Result<String, String> {
         .collect())
 }
 
-/// `winmm.dll` (the proxy that loads `MystPaxInternalServer.dll` — see
-/// MystPaxInternalServer's build) and the DLL itself must both be present
+/// `winmm.dll` (the proxy that loads `MysticParadox.dll`) and the runtime DLL
+/// itself must both be present
 /// alongside the game exe. This is a presence/non-empty check, not a hash
 /// match — unlike the game exe (checked against the backend's approved-hash
 /// allow-list), these are project-owned files that get rebuilt far more often,
@@ -28,7 +28,7 @@ pub fn verify_runtime_dlls_present(game_dir: &Path) -> Result<(), String> {
     const GENERIC_ERR: &str =
         "Runtime binaries are missing or corrupted. Repair your installation.";
 
-    for name in [WINMM_DLL_NAME, INTERNAL_SERVER_DLL_NAME] {
+    for name in [WINMM_DLL_NAME, RUNTIME_DLL_NAME] {
         let path = game_dir.join(name);
         let metadata = std::fs::metadata(&path).map_err(|_| GENERIC_ERR.to_string())?;
 
@@ -75,7 +75,7 @@ mod tests {
             std::env::temp_dir().join(format!("mystpax-dll-empty-test-{}", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
         fs::write(dir.join(WINMM_DLL_NAME), b"").unwrap();
-        fs::write(dir.join(INTERNAL_SERVER_DLL_NAME), b"content").unwrap();
+        fs::write(dir.join(RUNTIME_DLL_NAME), b"content").unwrap();
 
         assert!(verify_runtime_dlls_present(&dir).is_err());
 
@@ -87,7 +87,7 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("mystpax-dll-ok-test-{}", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
         fs::write(dir.join(WINMM_DLL_NAME), b"content").unwrap();
-        fs::write(dir.join(INTERNAL_SERVER_DLL_NAME), b"content").unwrap();
+        fs::write(dir.join(RUNTIME_DLL_NAME), b"content").unwrap();
 
         assert!(verify_runtime_dlls_present(&dir).is_ok());
 

--- a/ParadoxRuntime/MysticParadox.vcxproj
+++ b/ParadoxRuntime/MysticParadox.vcxproj
@@ -23,7 +23,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{50a2ca7e-947b-4a94-ae68-49b664cdc6fc}</ProjectGuid>
     <RootNamespace>ParadoxRuntime</RootNamespace>
-    <TargetName>MystPaxInternalServer</TargetName>
+    <TargetName>MysticParadox</TargetName>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -91,7 +91,7 @@ Build the runtime:
     cd ParadoxRuntime
     .\_build.bat
 
-The x64 Release output is MystPaxInternalServer.dll.
+The x64 Release output is MysticParadox.dll.
 
 Build the loader:
 
@@ -100,11 +100,11 @@ Build the loader:
 
 Copy these two files beside Dauntless-Win64-Shipping.exe:
 
-- ParadoxRuntime\x64\Release\MystPaxInternalServer.dll
+- ParadoxRuntime\x64\Release\MysticParadox.dll
 - tools\RuntimeLoader\target\release\winmm.dll
 
 The loader forwards calls to the real Windows winmm library and loads only
-MystPaxInternalServer.dll by default. Do not add untrusted DLLs to mystic_loader.ini.
+MysticParadox.dll by default. Do not add untrusted DLLs to mystic_loader.ini.
 
 ## 5. Start the services
 
@@ -143,7 +143,7 @@ The compile-time settings bind native account requests and runtime downloads to 
 Runtime manifests must be signed by the generated Ed25519 private key. Publish both the runtime
 and loader from `ParadoxLauncher` before the first client install:
 
-    node scripts/publish-runtime-update.mjs --dll ..\ParadoxRuntime\x64\Release\MystPaxInternalServer.dll --extra ..\tools\RuntimeLoader\target\release\winmm.dll --target client --version 0.1.0 --changelist 392819 --channel stable --output ..\ParadoxBackend\updates --base-url https://your-hostname --key .secrets\selfhost-runtime-update.private.pem
+    node scripts/publish-runtime-update.mjs --dll ..\ParadoxRuntime\x64\Release\MysticParadox.dll --extra ..\tools\RuntimeLoader\target\release\winmm.dll --target client --version 0.1.0 --changelist 392819 --channel stable --output ..\ParadoxBackend\updates --base-url https://your-hostname --key .secrets\selfhost-runtime-update.private.pem
 
 Use a new semantic version for each published artifact. See
 [ParadoxLauncher\UPDATE_CHANNEL.md](../ParadoxLauncher/UPDATE_CHANNEL.md) for channel and rollout
@@ -182,7 +182,7 @@ Set ADMIN_TOTP_SECRET and ADMIN_ALLOWED_ORIGINS before enabling the admin routes
 
 ### The launcher says the runtime is missing
 
-Confirm both winmm.dll and MystPaxInternalServer.dll are non-empty and beside the exact executable
+Confirm both winmm.dll and MysticParadox.dll are non-empty and beside the exact executable
 selected in the launcher.
 
 ### Game sessions are rejected

--- a/tools/RuntimeLoader/README.md
+++ b/tools/RuntimeLoader/README.md
@@ -1,7 +1,7 @@
 # Paradox Runtime Loader
 
 A small winmm.dll proxy that forwards multimedia calls to the real Windows system library and
-loads MystPaxInternalServer.dll from the game directory during process startup.
+loads MysticParadox.dll from the game directory during process startup.
 
 ## Build
 
@@ -10,10 +10,10 @@ loads MystPaxInternalServer.dll from the game directory during process startup.
 
 Output: target\release\winmm.dll.
 
-Place winmm.dll and the runtime renamed to MystPaxInternalServer.dll beside
+Place winmm.dll and MysticParadox.dll beside
 Dauntless-Win64-Shipping.exe. The loader can optionally read mystic_loader.ini; when present,
 list one additional project-owned DLL path per line. These entries never replace the required
-MystPaxInternalServer.dll. Relative paths resolve from the game directory.
+MysticParadox.dll. Relative paths resolve from the game directory.
 
 Do not list untrusted DLLs. Every configured library executes inside the game process.
 

--- a/tools/RuntimeLoader/src/lib.rs
+++ b/tools/RuntimeLoader/src/lib.rs
@@ -10,7 +10,7 @@ use winapi::um::winnt::DLL_PROCESS_ATTACH;
 mod exports;
 pub mod proxy;
 
-const DLLS: [&str; 1] = ["MystPaxInternalServer.dll"];
+const DLLS: [&str; 1] = ["MysticParadox.dll"];
 
 /// Optional additional-DLL list placed next to the proxy DLL.
 const INI_FILE: &str = "mystic_loader.ini";


### PR DESCRIPTION
## Summary

- standardize the public native runtime artifact on `MysticParadox.dll`
- align the launcher installer/updater, proxy loader, Visual Studio target, publisher metadata, and self-hosting docs
- emit publisher manifests with the `ParadoxRuntime` component expected by the Director

## Why

The public repository mixed `MystPaxInternalServer.dll` and `MysticParadox.dll`. That mismatch meant the public build output, launcher, loader, publisher, and Director could disagree about which runtime DLL to install or load.

## Impact

Self-hosters now build, publish, install, verify, and load one consistently named runtime: `MysticParadox.dll`.

## Validation

- audited all added lines for credentials, private keys, personal paths, internal hosts, and private-source references
- confirmed no binary or untracked files are included
- `cargo fmt --check`, strict Clippy, and all 20 launcher tests
- RuntimeLoader formatting, strict Clippy, tests, and release build
- publisher `node --check`
- MSBuild property evaluation confirms `TargetFileName=MysticParadox.dll`
- `git diff --check`

The full C++ compile still requires the generated SDK described in `docs/GENERATING_SDK.md`.